### PR TITLE
add php-xml to apt installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM chambana/uwsgi-php:latest
 MAINTAINER Josh King <jking@chambana.net>
 
 RUN apt-get -qq update && \
-	apt-get install -y --no-install-recommends ca-certificates unzip wget && \
+	apt-get install -y --no-install-recommends ca-certificates unzip wget php-xml && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
fixes #1 

Adds `php-xml`  to apt installs.